### PR TITLE
testing ipaddress requirements

### DIFF
--- a/DenyHosts/util.py
+++ b/DenyHosts/util.py
@@ -6,10 +6,12 @@ from smtplib import SMTPHeloError
 import sys
 from textwrap import dedent
 import time
-try:
+
+py_version = sys.version_info
+if py_version.major == 2:
     # python 2
     from ipaddr import IPAddress
-except:
+elif py_version.major == 3:
     # python 3
     from ipaddress import ip_address
 
@@ -189,18 +191,14 @@ def normalize_whitespace(string):
 
 def is_valid_ip_address(process_ip):
     ip = None
-    try:
+    if py_version.major == 2:
+        # python 2
         ip = IPAddress(process_ip)
-    except:
-        try:
-            ip = ip_address(process_ip)
-        except:
-            pass
+    elif py_version.major == 3:
+        # python 3
+        ip = ip_address(process_ip)
 
-    if ip is None:
-        return False
-
-    if ip.is_reserved or ip.is_private or \
+    if ip is None or ip.is_reserved or ip.is_private or \
             ip.is_loopback or ip.is_unspecified or \
             ip.is_multicast or ip.is_link_local:
         return False

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,13 +2,25 @@ from __future__ import print_function, unicode_literals
 
 import unittest
 
-from DenyHosts.util import is_false, is_true, parse_host
+from DenyHosts.util import is_false, is_true, parse_host, is_valid_ip_address
 
 # List of 2-tuples: line to parse, expected host
 HOST_TEST_DATA = [
     ('host', 'host'),
     ('ALL:127.0.0.1', '127.0.0.1'),
     (3, ''),
+]
+
+TEST_IPS = [
+    ('127.0.0.1', False),
+    ('127.0.1.1', False),
+    ('10.5.0.234', False),
+    ('172.16.0.1', False),
+    ('192.168.0.1', False),
+    ('224.2.0.45', False),
+    ('8.8.8.8', True),
+    ('4.4.2.2', True),
+    ('49.88.112.60', True)
 ]
 
 class UtilsTest(unittest.TestCase):
@@ -33,3 +45,7 @@ class UtilsTest(unittest.TestCase):
     def test_parse_host(self):
         for line, expected in HOST_TEST_DATA:
             self.assertEqual(parse_host(line), expected)
+
+    def test_valid_ip(self):
+        for ip, expected in TEST_IPS:
+            self.assertEqual(is_valid_ip_address(ip), expected)


### PR DESCRIPTION
adjusting to detect py_version rather than doing a try except clause
adding a test for the is_valid_ip_address section